### PR TITLE
Let aggregation pipelines use more memory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>11.0.19</version>
+      <version>12.0.15</version>
     </dependency>
     <dependency>
       <groupId>com.github.luben</groupId>

--- a/src/main/java/org/schambon/loadsimrunner/runner/AggregationRunner.java
+++ b/src/main/java/org/schambon/loadsimrunner/runner/AggregationRunner.java
@@ -17,7 +17,7 @@ public class AggregationRunner extends AbstractRunner {
 
         var start = System.currentTimeMillis();
         var i = 0;
-        var iterator = mongoColl.aggregate(pipeline).iterator();
+        var iterator = mongoColl.aggregate(pipeline).allowDiskUse(true).iterator();
         while (iterator.hasNext()) {
             iterator.next();
             i++;


### PR DESCRIPTION
"Use [allowDiskUse()](https://www.mongodb.com/docs/manual/reference/method/cursor.allowDiskUse/#mongodb-method-cursor.allowDiskUse) to either allow or prohibit writing temporary files on disk when a pipeline stage exceeds the 100 megabyte limit. Starting in MongoDB 6.0, operations that require greater than 100 megabytes of memory automatically write data to temporary files by default."

https://www.mongodb.com/docs/manual/reference/method/cursor.allowDiskUse/

Without this modification, some aggregation pipelines are told by the server that there is Insufficient Memory to execute (in an exception).